### PR TITLE
missing return statement in lambda body

### DIFF
--- a/src/components/Buildings/BuildMenu.vue
+++ b/src/components/Buildings/BuildMenu.vue
@@ -38,7 +38,10 @@
     components: {Building, MultiBuy},
     computed: {
       anyupgrades() {
-        return this.$root.store_buildings.some(({name,title}) => {title==="The same"?false:upgradeable(name, this.$store.getters.buildinglevels[name], this.$store.getters.boughtupgrades[name])});
+        return this.$root.store_buildings.some(({name,title}) => {
+        return title==="The same"?false
+                  :upgradeable(name, this.$store.getters.buildinglevels[name],
+                  this.$store.getters.boughtupgrades[name])});
       },
       densebuildingmenu() {
         return this.$store.getters.densebuildingmenu;


### PR DESCRIPTION
UPGRADE ALL currently is locked, even though upgrades are buyable.

Maybe remove the restriction all together?